### PR TITLE
fix: add skipLibCheck to resolve parse5/entities moduleResolution error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## Summary

Multiple Renovate/Dependabot PRs are failing `check-code-quality` CI due to a TypeScript build error:

```
node_modules/parse5/dist/tokenizer/index.d.ts(3,31): error TS2307:
Cannot find module 'entities/decode' or its corresponding type declarations.
→ Consider updating to 'node16', 'nodenext', or 'bundler' moduleResolution
```

The `parse5` package uses `package.json` exports to expose `entities/decode`, which requires a newer `moduleResolution` setting. Since this project uses `module: "commonjs"`, the simplest compatible fix is to add `"skipLibCheck": true` which skips type checking of `.d.ts` files in `node_modules`.

## Impact

This fixes `check-code-quality` CI failures on these PRs:
- #627 (update @types/jsdom to v28.0.3)
- #593 (update TypeScript to v6)
- #388 (update sentry-javascript to v10)
- #386 (update node-cron to v4)
- #650 (bump @opentelemetry/core and @sentry/node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EydGyq7gPdRj8TjpA4BGkg)_