### PR TITLE
fix: prepare codebase for Sentry v10, node-cron v4, and TypeScript v6

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,11 +1,11 @@
-import cron, { ScheduleOptions } from 'node-cron';
+import cron from 'node-cron';
 import { WebClient } from '@slack/web-api';
 import { DateTime } from 'luxon';
 import { HorimiyaRssService } from './services/horimiyaRssService';
 import { getView } from './views/feedComic';
 
 const slackClient = new WebClient(process.env.SLACK_BOT_TOKEN);
-const cronSettings: ScheduleOptions = {
+const cronSettings = {
   timezone: 'Asia/Tokyo',
 };
 

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/node';
-import type { ExclusiveEventHintOrCaptureContext } from '@sentry/core/build/types/utils/prepareEvent';
 
 const environment = process.env.NODE_ENV;
 const isProduction = process.env.NODE_ENV === 'production';
@@ -19,7 +18,7 @@ export function initSentry() {
 
 export function captureException(
   err: Error,
-  captureContext?: ExclusiveEventHintOrCaptureContext,
+  captureContext?: Parameters<typeof Sentry.captureException>[1],
 ) {
   if (isProduction) {
     Sentry.captureException(err, captureContext);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
+    "rootDir": "./src",
     "outDir": "./lib",
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary

Fixes to unblock Renovate/Dependabot PRs that are currently failing CI:

- **`src/sentry.ts`**: Remove import from internal `@sentry/core/build/types/utils/prepareEvent` path (removed in Sentry v10). Use `Parameters<typeof Sentry.captureException>[1]` instead — always correct regardless of Sentry version. Unblocks PRs #388 and #650.
- **`src/scheduler.ts`**: Remove `ScheduleOptions` named import from `node-cron` — it is no longer a named export in node-cron v4. Use an untyped object literal (TypeScript infers compatibility). Unblocks PR #386.
- **`tsconfig.json`**: Add `rootDir: ./src` — required by TypeScript v6 (TS5011) when `outDir` is set. Unblocks PR #593.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EydGyq7gPdRj8TjpA4BGkg)_