### PR TITLE
fix(tsconfig): exclude test files from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
   },
   "include": [
     "src/**/*",
-    "!src/tool/**/*"
+    "!src/tool/**/*",
+    "!src/**/*.test.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
TypeScript v6 strictly compiles all files matching `include` patterns, causing `TS2593` errors when jest globals (`test`, `describe`, `expect`) are referenced in test files that are included in the main build.

## Fix

Add `"!src/**/*.test.ts"` to the `include` array in `tsconfig.json` to exclude test files from the main TypeScript compilation.

Same fix already applied to `slack_app_boilerplate` in PR #483.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EydGyq7gPdRj8TjpA4BGkg)_